### PR TITLE
Ensure firewalld is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: ensure firewalld is installed
   package:
-    state: latest
+    state: present
     name:
       - firewalld
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 
 - name: ensure firewalld is installed
-  become: true
   package:
     state: latest
     name:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: ensure firewalld is installed
+  become: true
+  package:
+    state: latest
+    name:
+      - firewalld
+
 - name: allow all internal communication (IPv4)
   firewalld:
     source: '{{ lookup("dig", item) }}'


### PR DESCRIPTION
It would make sense to make sure firewalld is installed on the system before we try to change the configs. This adds the appropriate task. 