### PR TITLE
Split handling of HTTP and HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Role Variables
 - `opencast_firewall_internal_hosts`
     - List of hosts between which to allow all network communication (default: `groups["all"]`)
 - `opencast_firewall_http_hosts`
-    - List of hosts to allow external HTTP(S) communications to (default: `groups["all"]`)
-	 - Often makes sense to set this to something like `groups["opencast"]`
+    - List of hosts to allow external HTTP communications to (default: `groups["all"]`)
+    - Often makes sense to set this to something like `groups["opencast"]`
+- `opencast_firewall_https_hosts`
+    - List of hosts to allow external HTTPS communications to (default: `opencast_firewall_http_hosts`)
 - `opencast_firewall_ipv4`
     - Look up IPv4 addresses of hostnames
 - `opencast_firewall_ipv6`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 opencast_firewall_internal_hosts: "{{ groups['all'] }}"
 opencast_firewall_http_hosts: "{{ groups['all'] }}"
+opencast_firewall_https_hosts: "{{ opencast_firewall_http_hosts }}"
 opencast_firewall_ipv4: true
 opencast_firewall_ipv6: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,13 +24,18 @@
     state: enabled
   loop: '{{ opencast_firewall_internal_hosts }}'
 
-- name: Allow https
+- name: Allow http
   when: inventory_hostname in opencast_firewall_http_hosts
   ansible.posix.firewalld:
-    service: "{{ item }}"
+    service: http
     permanent: true
     immediate: true
     state: enabled
-  loop:
-    - http
-    - https
+
+- name: Allow https
+  when: inventory_hostname in opencast_firewall_https_hosts
+  ansible.posix.firewalld:
+    service: https
+    permanent: true
+    immediate: true
+    state: enabled


### PR DESCRIPTION
This patch allows users to configure HTTP and HTTPS separately, although the group allowed to communicate via HTTPS still defaults to the group allowed to communicate via HTTP.

This allows user to, for example, make hosts available via HTTP for updating Let's Encrypt certificates while the main communication which is done only via HTTPS anyway is still not open.

*The CI problems should be fixed with #2.*